### PR TITLE
Add React + Firebase skeleton for autodiag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# arteco-autodiag
+# Arteco Autodiag
+
+Proyecto de ejemplo de una landing page y asistente de autodiagnóstico para empresas.
+
+## Scripts
+
+- `npm run dev` para entorno de desarrollo.
+- `npm run build` para generar la carpeta `dist` que servirá Firebase Hosting.
+
+## Firebase
+
+Configura las credenciales en `src/firebase.js` y usa `firebase deploy` para subir a Firebase Hosting.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,7 @@
+{
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [{"source": "**", "destination": "/index.html"}]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arteco-autodiag",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1",
+    "firebase": "^9.23.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Arteco Autodiag</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-50">
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,14 @@
+import { Routes, Route } from 'react-router-dom';
+import LandingPage from './pages/LandingPage';
+import DiagnosticWizard from './pages/DiagnosticWizard';
+import ThankYouPage from './pages/ThankYouPage';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/diagnostico" element={<DiagnosticWizard />} />
+      <Route path="/gracias" element={<ThankYouPage />} />
+    </Routes>
+  );
+}

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -1,0 +1,22 @@
+export default function Question({ question, options, value, onChange }) {
+  return (
+    <div>
+      <h2 className="text-xl mb-4">{question}</h2>
+      <div className="space-y-2">
+        {options.map((opt) => (
+          <label key={opt} className="flex items-center space-x-2">
+            <input
+              type="radio"
+              name="answer"
+              value={opt}
+              checked={value === opt}
+              onChange={() => onChange(opt)}
+              className="form-radio text-blue-600"
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -1,0 +1,17 @@
+const options = [
+  ['Menos de un día', 'Entre 1 y 7 días', 'Más de una semana'],
+  ['Varias veces al día', 'Semanalmente', 'Mensualmente'],
+  ['Sí', 'Parcialmente', 'No'],
+  ['Sí', 'Parcialmente', 'No'],
+  ['Desacopladas', 'Monolitos', 'Mixto'],
+  ['Con herramientas de monitoreo', 'Revisiones manuales', 'No lo identificamos'],
+  ['Sí', 'Parcialmente', 'No'],
+  ['Nunca', '1-2 veces', 'Más de 2 veces'],
+  ['Sí', 'Parcialmente', 'No'],
+  ['Definida y documentada', 'Informal', 'No existe'],
+  ['Sí', 'Ocasionalmente', 'No'],
+  ['Sí', 'No'],
+  ['Alta inversión', 'Inversión moderada', 'Baja o nula']
+];
+
+export default options;

--- a/src/data/questions.js
+++ b/src/data/questions.js
@@ -1,0 +1,17 @@
+const questions = [
+  '¿Cuánto tiempo tarda tu equipo en desplegar un cambio en producción?',
+  '¿Con qué frecuencia puedes hacer despliegues sin interrumpir el servicio?',
+  '¿Usas herramientas de automatización como Jenkins, ArgoCD o similares?',
+  '¿Está tu sistema preparado para escalar automáticamente según la demanda?',
+  '¿Tienes aplicaciones desacopladas o siguen siendo monolitos?',
+  '¿Cómo identificas cuellos de botella o fallos en tu sistema?',
+  '¿Tienes KPIs definidos sobre el rendimiento de tus aplicaciones?',
+  '¿Has tenido caídas o problemas de disponibilidad en los últimos 6 meses?',
+  '¿Tu arquitectura está preparada para tolerar fallos y mantener servicio?',
+  '¿Dispones de una metodología clara para desarrollar y desplegar software?',
+  '¿Recibes formación o auditorías técnicas externas regularmente?',
+  '¿Contratas actualmente algún servicio de IT vía outsourcing?',
+  '¿Qué previsión de inversión tecnológica tienes para los próximos 3 años?'
+];
+
+export default questions;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/DiagnosticWizard.jsx
+++ b/src/pages/DiagnosticWizard.jsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import questions from '../data/questions';
+import options from '../data/options';
+import Question from '../components/Question';
+import { db } from '../firebase';
+import { collection, addDoc, Timestamp } from 'firebase/firestore';
+
+export default function DiagnosticWizard() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const utm = Object.fromEntries(new URLSearchParams(location.search));
+
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState(Array(questions.length).fill(''));
+
+  const handleChange = (value) => {
+    setAnswers((prev) => {
+      const copy = [...prev];
+      copy[step] = value;
+      return copy;
+    });
+  };
+
+  const handleNext = () => {
+    if (step < questions.length - 1) {
+      setStep(step + 1);
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await addDoc(collection(db, 'diagnostics'), {
+        answers,
+        utm,
+        createdAt: Timestamp.now(),
+      });
+      navigate('/gracias');
+    } catch (e) {
+      console.error('Error saving data', e);
+    }
+  };
+
+  const progress = Math.round(((step + 1) / questions.length) * 100);
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <div className="h-2 bg-gray-200 rounded mb-4">
+        <div className="h-full bg-blue-500 rounded" style={{ width: `${progress}%` }} />
+      </div>
+      <Question
+        question={questions[step]}
+        options={options[step]}
+        value={answers[step]}
+        onChange={handleChange}
+      />
+      <div className="mt-6 flex justify-between">
+        {step < questions.length - 1 ? (
+          <button
+            onClick={handleNext}
+            disabled={!answers[step]}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            Siguiente
+          </button>
+        ) : (
+          <button
+            onClick={handleSubmit}
+            disabled={answers.some((a) => !a)}
+            className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+          >
+            Enviar resultados para su análisis gratuito por parte del equipo de Arteco
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
+      <h1 className="text-3xl font-bold mb-4">Plataformas IT no \u00e1giles generan problemas:</h1>
+      <ul className="text-left list-disc list-inside mb-6">
+        <li>Lentos despliegues de cambios.</li>
+        <li>Falta de observabilidad.</li>
+        <li>Dependencia de sistemas monol\u00edticos.</li>
+        <li>Ausencia de automatizaci\u00f3n.</li>
+      </ul>
+      <Link
+        to="/diagnostico"
+        className="px-6 py-3 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Comienza tu autodiagn\u00f3stico gratuito
+      </Link>
+    </div>
+  );
+}

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function ThankYouPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
+      <h1 className="text-2xl font-bold mb-4">\u00a1Gracias por enviar tus respuestas!</h1>
+      <p className="mb-6">Nuestro equipo analizar\u00e1 tu informaci\u00f3n y se pondr\u00e1 en contacto contigo.</p>
+      <Link to="/" className="text-blue-600 hover:underline">Volver al inicio</Link>
+    </div>
+  );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  build: {
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
## Summary
- set up React project using Vite
- add landing page with CTA
- implement diagnostic wizard and progress bar
- store answers in Firestore
- configure Firebase Hosting

## Testing
- `npm install` *(fails: internet access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8f4c61908323a0552f33910d1280