### PR TITLE
Fix PDF contents and store all answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@types/node": "^20",
         "@types/pdfkit": "^0.14.0",
+        "@types/pg": "^8.15.4",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "postcss": "^8",
@@ -2833,6 +2834,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@types/node": "^20",
     "@types/pdfkit": "^0.14.0",
+    "@types/pg": "^8.15.4",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "postcss": "^8",

--- a/src/app/api/pdf/route.ts
+++ b/src/app/api/pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import PDFDocument from 'pdfkit';
 import { generateRecommendations, Answers } from '@/lib/recommendations';
+import { questions } from '@/app/diagnostico/questions';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -25,8 +26,11 @@ export async function GET(request: NextRequest) {
   doc.fontSize(20).text('Resultados del Diagnóstico', { align: 'center' });
   doc.moveDown();
 
-  Object.entries(data.answers).forEach(([question, answer]) => {
-    doc.fontSize(12).text(`${question}: ${answer}`);
+  const questionMap = new Map(questions.map((q) => [q.id, q.question]));
+
+  Object.entries(data.answers).forEach(([id, answer]) => {
+    const questionText = questionMap.get(id) || id;
+    doc.fontSize(12).text(`${questionText}: ${answer}`);
   });
 
   doc.moveDown();

--- a/src/app/diagnostico/actions.ts
+++ b/src/app/diagnostico/actions.ts
@@ -17,14 +17,11 @@ export async function submitDiagnosis(formData: FormData) {
     utm_content: formData.get("utm_content")?.toString(),
   };
 
-  const questionMap = new Map(questions.map((q) => [q.id, q.question]));
+  const questionIds = new Set(questions.map((q) => q.id));
 
   for (const [key, value] of formData.entries()) {
-    if (questionMap.has(key)) {
-      const questionText = questionMap.get(key);
-      if (questionText) {
-        answers[questionText] = value.toString();
-      }
+    if (questionIds.has(key)) {
+      answers[key] = value.toString();
     }
   }
 

--- a/src/app/diagnostico/page.tsx
+++ b/src/app/diagnostico/page.tsx
@@ -92,6 +92,13 @@ function DiagnosticWizard() {
             <input type="hidden" name="utm_term" value={searchParams.get("utm_term") || ""} />
             <input type="hidden" name="utm_content" value={searchParams.get("utm_content") || ""} />
 
+            {/* Hidden fields for previous answers */}
+            {Object.entries(answers).map(([id, value]) => (
+              id !== currentQuestion.id ? (
+                <input key={`hidden-${id}`} type="hidden" name={id} value={value} />
+              ) : null
+            ))}
+
           </CardContent>
           <CardFooter className="flex justify-between border-t pt-6">
             <Button type="button" variant="outline" onClick={handlePrev} disabled={currentStep === 0 || isPending}>


### PR DESCRIPTION
## Summary
- save answers using question IDs
- include hidden fields for previous answers on the diagnostic form
- show question text in generated PDF
- add `@types/pg` for type checking

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_686aa90e8a348323a7d5e0bf423ef14f